### PR TITLE
Logger actor need LoggerMessageQueueSemantics to respect Akka contract

### DIFF
--- a/src/main/scala/de/heikoseeberger/akkalog4j/Log4jLogger.scala
+++ b/src/main/scala/de/heikoseeberger/akkalog4j/Log4jLogger.scala
@@ -17,7 +17,8 @@
 package de.heikoseeberger.akkalog4j
 
 import akka.actor.Actor
-import akka.event.DummyClassForStringSources
+import akka.dispatch.RequiresMessageQueue
+import akka.event.{LoggerMessageQueueSemantics, DummyClassForStringSources}
 import akka.event.Logging._
 import akka.util.Helpers
 import org.apache.logging.log4j.{ LogManager, ThreadContext }
@@ -53,7 +54,7 @@ object Log4jLogger {
   private def formatTimestamp(timestamp: Long) = Helpers.currentTimeMillisToUTCString(timestamp)
 }
 
-final class Log4jLogger extends Actor {
+final class Log4jLogger extends Actor with RequiresMessageQueue[LoggerMessageQueueSemantics] {
   import Log4jLogger._
 
   override def receive = {


### PR DESCRIPTION
Logger actor need LoggerMessageQueueSemantics to respect Akka contract for logger mailbox semantics, otherwise it will use the default mailbox, I want to have my own logger mailbox which I can do for akka-slf4j and default:

```
     requirements {
        "akka.event.LoggerMessageQueueSemantics" =
          akka.actor.mailbox.logger-queue
      }

      # The LoggerMailbox will drain all messages in the mailbox
      # when the system is shutdown and deliver them to the StandardOutLogger.
      # Do not change this unless you know what you are doing.
      logger-queue {
        mailbox-type = "akka.event.LoggerMailboxType"
      }
```
